### PR TITLE
Multiple fixes

### DIFF
--- a/src/components/error.tsx
+++ b/src/components/error.tsx
@@ -2,7 +2,7 @@ import { Component } from "inferno"
 
 interface Props {
   visible: boolean
-  message: string
+  message: string | HTMLElement
 }
 
 export class Error extends Component<Props> {
@@ -16,7 +16,7 @@ export class Error extends Component<Props> {
           <div class="message-body">
             <div class="content">
               <h4>Message</h4>
-              <pre>{this.props.message}</pre>
+              {(this.props.message instanceof HTMLElement) ? this.props.message : <pre>{this.props.message}</pre> }
               <h4>Potential Fixes</h4>
               <ul>
                 <li>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,24 @@
 import { render } from 'inferno'
 import { App } from "./components/app"
 import { Logquacious } from "./services/logquacious"
+import { Error } from "./components/error"
 
-fetch("config.json")
-  .then(resp => resp.json()
-    .then(config => {
-        const manager = new Logquacious(config)
-        render(<App log={manager}/>, document.getElementById('app'))
-      }
-    )
-  )
+const app = document.getElementById('app')
+
+export async function loadConfig() {
+  try {
+    const resp = await fetch("config.json")
+    const manager = new Logquacious(await resp.json())
+    render(<App log={manager}/>, app)
+  } catch (e) {
+    console.log(e)
+    console.error("Could not load config.json. Please place it in the same path as index.html.")
+    render((
+      <Error message={`There was an error loading config.json: ${e}`} visible={true}/>
+    ), app)
+  }
+}
+
+loadConfig()
+render(<b>Loading Logquacious</b>, app)
+

--- a/src/services/histogram.ts
+++ b/src/services/histogram.ts
@@ -474,7 +474,12 @@ export class Histogram {
   // A resize basically needs to recalculate sizes and request new buckets.
   // We don't want to spam many of them so do a debounce.
   attachResizeEvents() {
-    const f = () => this.search(this.query)
+    const f = () => {
+      if (!this.query) {
+        return
+      }
+      this.search(this.query)
+    }
     let timer: number
     window.addEventListener('resize', () => {
       clearTimeout(timer)


### PR DESCRIPTION
* always include the index as a prefix again
* assume no forward slash separators in arguments
* error component also accepts HTMLElement
* don't error on resize without existing query
* show error when config.json not set up correctly