### PR TITLE
remove the tie breaker in sort

### DIFF
--- a/src/backends/elasticsearch.ts
+++ b/src/backends/elasticsearch.ts
@@ -170,11 +170,6 @@ export class Elasticsearch implements IDataSource {
           order: (searchAfterAscending === true) ? 'asc' : 'desc'
         }
       },
-      {
-        "_id": {
-          order: 'asc'
-        },
-      },
     ]
 
     if (cursor !== undefined) {


### PR DESCRIPTION
This was causing memory problems in our systems. It appears that it is not recommended.