### PR TITLE
Correct linking with inaccurate timestamps

### DIFF
--- a/src/helpers/time.ts
+++ b/src/helpers/time.ts
@@ -132,7 +132,7 @@ export class Time {
 
   static whenToComputed(when: When): string {
     const w = Time.whenToMoment(when)
-    return w && w.format() || ""
+    return w && w.toISOString(true) || ""
   }
 
   static whenToElastic(when: When): string | undefined {

--- a/src/helpers/time.ts
+++ b/src/helpers/time.ts
@@ -157,7 +157,7 @@ export class Time {
       case "invalid":
         return ""
       case "moment":
-        return when.moment.format()
+        return when.moment.toISOString()
       case "relative":
         return `${when.count}${when.unit.substring(0, 1)}`
       default:

--- a/src/services/log.ts
+++ b/src/services/log.ts
@@ -236,7 +236,7 @@ export class LogFormatter {
 
             } else if (target.classList.contains('link-button')) {
               const sharedQuery = getQuery()
-                .withFocusCursor(JSON.stringify(data))
+                .withFocus(full._id, JSON.stringify(data))
                 .withFixedTimeRange()
               const w = window.location
               this.copyHelper.copy(`${w.protocol}//${w.host}${w.pathname}?${sharedQuery.toURL()}`)
@@ -539,7 +539,7 @@ export function showContextButton(filter: ContextFilter, obj: any, cursor: any, 
     .map(k => `${k}:${JSON.stringify(obj[k])}`)
     .join(" ")
   const contextQuery = qm.getQuery()
-    .withFocusCursor(JSON.stringify(cursor))
+    .withFocus(obj._id, JSON.stringify(cursor))
     .withFixedTimeRange()
     .withNewTerms(newTerms)
   const url = `?${contextQuery.toURL()}`

--- a/src/services/log.ts
+++ b/src/services/log.ts
@@ -146,6 +146,7 @@ export class LogFormatter {
     let fragment = document.importNode(this.templateContent, true)
     fragment.firstElementChild.dataset.cursor = JSON.stringify(cursor)
     fragment.firstElementChild.dataset.ts = entry['@timestamp']
+    fragment.firstElementChild.dataset.id = entry['_id']
 
     let fields = ''
     for (const rule of this.config.collapsedFormatting) {

--- a/src/services/logquacious.ts
+++ b/src/services/logquacious.ts
@@ -235,7 +235,7 @@ export class Logquacious {
     }
 
     // Clear out loaded focusCursor, since it is specific for the initial load only.
-    this.query = query.withFocusCursor()
+    this.query = query.withFocus()
     this.histogram.setQuery(this.query)
   }
 

--- a/src/services/logquacious.ts
+++ b/src/services/logquacious.ts
@@ -227,8 +227,8 @@ export class Logquacious {
     if (nextPage) {
       // Keep the apparent scroll position when inserting dom elements above.
       this.results.restoreScroll(nextPageOlder)
-    } else if (query.focusCursor) {
-      this.results.focusCursor(query.focusCursor)
+    } else if (query.focusId) {
+      this.results.focusID(query.focusId)
     } else {
       // Scroll to latest after all the results are in, only on first page load.
       this.results.scrollToLatest()

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -13,6 +13,7 @@ export class Query {
   endTime: When
   filters: Filter[]
   focusCursor?: string
+  focusId?: string
 
   constructor() {
     // undefined means there hasn't been a search submitted yet
@@ -22,6 +23,7 @@ export class Query {
     this.endTime = DefaultEndTime
     this.filters = []
     this.focusCursor = undefined
+    this.focusId = undefined
   }
 
   clone(): Query {
@@ -32,6 +34,7 @@ export class Query {
     q.endTime = this.endTime
     q.filters = this.filters
     q.focusCursor = this.focusCursor
+    q.focusId = this.focusId
     return q
   }
 
@@ -56,7 +59,8 @@ export class Query {
     q.pageSize = parseInt(result["n"]) || DefaultPageSize
     q.startTime = result["t"] ? Time.parseText(result["t"]) : DefaultStartTime
     q.endTime = result["u"] ? Time.parseText(result["u"]) : DefaultEndTime // u for until
-    q.focusCursor = result["id"]
+    q.focusCursor = result["cursor"]
+    q.focusId = result["id"]
 
     for (const idx in filters) {
       const filter = filters[idx]
@@ -105,7 +109,10 @@ export class Query {
       values.u = Time.whenToMoment(this.endTime).toISOString()
     }
     if (this.focusCursor) {
-      values.id = this.focusCursor
+      values.cursor = this.focusCursor
+    }
+    if (this.focusId) {
+      values.id = this.focusId
     }
     for (const f of this.filters) {
       values[f.urlKey] = f.selected || ""
@@ -162,8 +169,9 @@ export class Query {
     return q
   }
 
-  withFocusCursor(cursor?: string): Query {
+  withFocus(id?: string, cursor?: string): Query {
     const q = this.clone()
+    q.focusId = id
     q.focusCursor = cursor
     return q
   }

--- a/src/services/results.ts
+++ b/src/services/results.ts
@@ -335,10 +335,10 @@ export class Results {
     return document.documentElement.scrollHeight || document.body.scrollHeight
   }
 
-  focusCursor(cursor: string) {
-    const e = this.find((e: HTMLElement) => e.dataset.cursor == cursor)
+  focusID(id: string) {
+    const e = this.find((e: HTMLElement) => e.dataset.id == id)
     if (!e) {
-      console.error(`Could not find cursor ${cursor} in results.`)
+      console.error(`Could not find id ${id} in results.`)
       return
     }
 


### PR DESCRIPTION
Couldn't use `_id` as a tie breaker in sort because of `CircuitBreakingException`, see https://discuss.elastic.co/t/too-large-data-for-id/179500 for a similar problem.

Instead:
* (TODO) Recommend users to use nanoseconds for their `@timestamp`.
* Use the timestamp to find the logs without expecting a particular order within the same millisecond.
* Scan through the results to find the `id` of the focused document.
* Fixed a few instances of milliseconds being stripped in the query so the results sometimes didn't fall near the focused log entry.