### PR TITLE
styling and layout fixes for histogram and scrollbars

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,11 @@
 [
   {
+    "when": "2020-03-19",
+    "pr": 121,
+    "what": "Styling and layout fixes for histogram and scrollbars.",
+    "type": "enhancement"
+  },
+  {
     "when": "2020-03-12",
     "pr": 118,
     "what": "Allow default terms per data source.",

--- a/app.sass
+++ b/app.sass
@@ -28,12 +28,29 @@ $nav-height: 3.25rem
 // Variables don't work with calc! https://github.com/sass/sass/issues/818
 $height-sans-padding: calc(100vh - #{$nav-height})
 
-body
-  // 3.25rem is from html.has-navbar-fixed-top
-  min-height: $height-sans-padding
+html, body
+  height: $height-sans-padding
+  width: 100vw
+  margin: 0
+  padding: 0
+  overflow: hidden
 
 body
-  overflow-x: auto
+  *::-webkit-scrollbar
+    height: 10px
+    width: 10px
+
+.main-columns.columns:not(:last-child)
+  margin: 0
+
+.logs-column
+  height: $height-sans-padding
+  overflow: auto
+  padding: 0
+
+.histogram-column
+  padding: 0
+  margin: 0
 
 .log-wide
   width: 100%
@@ -75,12 +92,13 @@ $stats-height: 1.5rem
   display: block
   font-family: $fixed-font-family
   font-size: 0.9rem
-  padding-top: 0.5rem
-  padding-bottom: 0.5rem
+  margin: 0
+  padding: 0.5rem 0
 
   .entry
     white-space: nowrap
-    margin-left: 0.8rem
+    padding-left: 0.5rem
+    padding-right: 0.5rem
 
     .unexpanded
       cursor: pointer
@@ -204,15 +222,12 @@ $stats-height: 1.5rem
   to
     background-position: -200% 0
 
-$histogram-width: 200px
-
 #histogram
+  position: relative
+
   svg
-    width: $histogram-width
-    position: fixed
-    right: 0
-    height: calc(100% - 52px)
-    background-color: rgba(0, 0, 0, 0.8)
+    width: 100%
+    height: calc(100vh - 52px)
     shape-rendering: geometricPrecision
 
     // We only want pointer events for the SVG itself
@@ -248,7 +263,7 @@ $histogram-width: 200px
 #histogram-tooltip
   background: $link
   color: white
-  position: fixed
+  position: absolute
   width: 200px
   height: 60px
   padding: 2px
@@ -256,7 +271,7 @@ $histogram-width: 200px
   font-family: $fixed-font-family
   border: 0
   pointer-events: none
-  right: $histogram-width
+  left: -200px
   text-align: right
   display: none
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,4 @@
-import { Component, Fragment } from "inferno"
+import { Component } from "inferno"
 import { Logs } from "./Logs"
 import { Range } from "../helpers/Time"
 import { AttachHistogramCallback, Histogram } from "./Histogram"
@@ -111,8 +111,7 @@ export class App extends Component<Props, State> {
   render() {
     const range: Range = [this.state.query.startTime, this.state.query.endTime]
     return (
-      <Fragment>
-        <Histogram onAttachHistogram={this.handleAttachHistogram} visible={this.state.display === Display.logs}/>
+      <>
         <nav class="navbar is-fixed-top log-nav">
           <Title/>
           <SearchBar
@@ -152,12 +151,20 @@ export class App extends Component<Props, State> {
           <progress id="loading" class="progress is-info log-progress"/>
         </nav>
 
-        <Logs visible={this.state.display === Display.logs} onAttachResults={this.handleAttachResults}/>
+        <div class="columns main-columns">
+          <div class="column logs-column">
+            <Logs visible={this.state.display === Display.logs} onAttachResults={this.handleAttachResults}/>
+          </div>
+          <div class="column is-2 histogram-column">
+            <Histogram onAttachHistogram={this.handleAttachHistogram} visible={this.state.display === Display.logs}/>
+          </div>
+        </div>
+
         <Welcome visible={this.state.display === Display.welcome}/>
         <Error visible={this.state.display === Display.error} message={this.state.errorMessage}/>
 
         <textarea id="copy-helper"/>
-      </Fragment>
+      </>
     )
   }
 }

--- a/src/components/Histogram.tsx
+++ b/src/components/Histogram.tsx
@@ -17,8 +17,8 @@ export class Histogram extends Component<Props> {
 
     return (
       <div style={{visibility}}>
-        <div id="histogram-tooltip"/>
         <div id="histogram">
+          <div id="histogram-tooltip"/>
           <svg ref={this.saveRef}/>
         </div>
       </div>

--- a/src/services/Histogram.ts
+++ b/src/services/Histogram.ts
@@ -57,7 +57,6 @@ export class Histogram {
   private callback: (q: Query) => void
   private interval: IRelative
   private isDragging: boolean
-  private svgOffset: Position
 
   constructor(es: IDataSource, direction: Direction) {
     this.es = es
@@ -198,10 +197,6 @@ export class Histogram {
     this.svgSize = {
       width: rect.width,
       height: rect.height,
-    }
-    this.svgOffset = {
-      x: rect.left,
-      y: rect.top,
     }
     this.innerSize = {
       width: this.svgSize.width - this.margin.left - this.margin.right,

--- a/src/services/Histogram.ts
+++ b/src/services/Histogram.ts
@@ -10,11 +10,6 @@ interface Size {
   height: number
 }
 
-interface Position {
-  x: number;
-  y: number
-}
-
 interface BucketInfo {
   bucket: Bucket
   hovering: boolean

--- a/src/services/Histogram.ts
+++ b/src/services/Histogram.ts
@@ -462,7 +462,7 @@ export class Histogram {
 
     this.tooltipVisible(true)
     this.tooltip
-      .style("top", `${this.svgOffset.y + y - height / 2 + this.margin.top}px`)
+      .style("top", `${y - height / 2 + this.margin.top}px`)
       .html(text)
   }
 

--- a/themes/dark.sass
+++ b/themes/dark.sass
@@ -5,6 +5,15 @@ $dark-menu-hover: darken($blue, 5%)
 $danger: hsl(40, 100%, 50%)
 
 html.dark-theme
+  *::-webkit-scrollbar-track
+    background-color: lighten($black-ter, 5%)
+
+  *::-webkit-scrollbar-thumb
+    background-color: darken(desaturate($blue, 20%), 20%)
+
+  *::-webkit-scrollbar-corner
+    background-color: lighten($black-ter, 5%)
+
   .time-picker .is-info
     color: black
     background-color: $warning

--- a/themes/light.sass
+++ b/themes/light.sass
@@ -1,4 +1,35 @@
 html.light-theme
+  *::-webkit-scrollbar-track
+    background-color: darken($white-ter, 5%)
+
+  *::-webkit-scrollbar-thumb
+    background-color: lighten($blue, 10%)
+
+  *::-webkit-scrollbar-corner
+    background-color: darken($white-ter, 5%)
+
+  #histogram
+    svg
+      text
+        color: $black-ter
+      line, path
+        stroke: $black-bis
+
+    .hovering
+      fill: $blue
+
+    .visible-range
+      fill: rgba(0, 0, 0, 0.2)
+      stroke: none
+
+    .downloaded-range
+      fill: rgba(0, 0, 0, 0.2)
+      stroke: none
+
+    .drag-range
+      fill: rgba(0, 0, 0, 0.3)
+      stroke: none
+
   $yellow-dark: #e88f00
 
   .has-text-warning


### PR DESCRIPTION
* Scroll bars are always shown and always around the log area.
* Scroll bars are styled so that they look good in the dark theme.
* Histogram is now a separate column instead of using fixed display (i.e., hovering over the logs). #55
* Histogram colour fixes in light mode. #57