### PR TITLE
Fix older result returns the same result problem

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,11 @@
 [
   {
+    "when": "2020-07-24",
+    "pr": 141,
+    "what": "Fix older result returns the same result problem",
+    "type": "bug"
+  },
+  {
     "when": "2020-06-10",
     "pr": 135,
     "what": "Fix broken exception links.",

--- a/src/services/Results.ts
+++ b/src/services/Results.ts
@@ -193,12 +193,14 @@ export class Results {
   }
 
   getBottomEntry(): HTMLElement {
+    let lastChunk: Element | undefined
     for (const chunk of this.logs.children) {
       if (chunk.children.length > 0) {
-        return chunk.children[chunk.children.length - 1] as HTMLElement
+        lastChunk = chunk
       }
     }
-    return undefined
+
+    return lastChunk ? lastChunk.children[lastChunk.children.length - 1] as HTMLElement : undefined
   }
 
   getEntryAt(idx: number): HTMLElement {


### PR DESCRIPTION
older result now gets the cursor from the correct last log entry