### PR TITLE
Adds an env variable to use a secondary index when sorting logs

### DIFF
--- a/demo/config.json
+++ b/demo/config.json
@@ -8,6 +8,75 @@
       "fields": "main"
     }
   ],
+  "filters": [
+    {
+      "id": "level",
+      "urlKey": "ll",
+      "title": "Log Level",
+      "default": null,
+      "type": "singleValue",
+      "items": [
+        {
+          "title": "All levels",
+          "id": null
+        },
+        {
+          "title": "Debug",
+          "id": "debug"
+        },
+        {
+          "title": "Info",
+          "id": "info"
+        },
+        {
+          "title": "Warn",
+          "id": "warn"
+        },
+        {
+          "title": "Error",
+          "id": "error"
+        }
+      ]
+    },
+    {
+      "id": "plevel",
+      "urlKey": "pll",
+      "title": "Log Level",
+      "default": null,
+      "type": "addTerms",
+      "items": [
+        {
+          "title": "All levels",
+          "id": null
+        },
+        {
+          "title": "Debug+",
+          "id": "debug",
+          "terms": "level:>=10000"
+        },
+        {
+          "title": "Info+",
+          "id": "info",
+          "terms": "level:>=20000"
+        },
+        {
+          "title": "Warn+",
+          "id": "warn",
+          "terms": "level:>=30000"
+        },
+        {
+          "title": "Error+",
+          "id": "error",
+          "terms": "level:>=40000"
+        },
+        {
+          "title": "Fatal+",
+          "id": "fatal",
+          "terms": "level:>=50000"
+        }
+      ]
+    }
+  ],
   "fields": {
     "main": {
       "timestamp": "@timestamp",

--- a/docker/config.json
+++ b/docker/config.json
@@ -11,6 +11,7 @@
   "fields": {
     "main": {
       "timestamp": "{{.TimestampField}}",
+      {{if .SecondaryIndex}}"secondaryIndex": "{{.SecondaryIndex}}" {{end}},
       "collapsedFormatting": [
         {
           "field": "{{.TimestampField}}",

--- a/docker/lq.go
+++ b/docker/lq.go
@@ -24,6 +24,7 @@ type Vars struct {
 	ESURL               string   `env:"ES_URL" name:"es-url" help:"ElasticSearch host to send queries to, e.g.: http://my-es-server:9200/ (ES_URL)"`
 	ESIndex             string   `env:"ES_INDEX" default:"*" help:"ElasticSearch index to search in. (ES_INDEX)"`
 	TimestampField      string   `env:"TIMESTAMP_FIELD" default:"@timestamp" help:"The field containing the main timestamp entry. (TIMESTAMP_FIELD)"`
+	SecondaryIndex      string   `env:"SECONDARY_INDEX" default:"" help:"The field containing a secondary index to sort if timestamps are equal. (SECONDARY_INDEX)"`
 	LevelField          string   `env:"LEVEL_FIELD" default:"level" help:"The field containing the log level. (LEVEL_FIELD)"`
 	ServiceField        string   `env:"SERVICE_FIELD" default:"service" help:"The field containing the name of the service. (SERVICE_FIELD)"`
 	MessageField        string   `env:"MESSAGE_FIELD" default:"message" help:"The field containing the main message of the log entry. (MESSAGE_FIELD)"`

--- a/src/backends/elasticsearch/Elasticsearch.ts
+++ b/src/backends/elasticsearch/Elasticsearch.ts
@@ -164,8 +164,17 @@ export class Elasticsearch implements IDataSource {
         [this.fieldsConfig.timestamp]: {
           order: (searchAfterAscending === true) ? 'asc' : 'desc'
         }
-      },
+      }
     ]
+    // We now have a secondary index to sort by if timestamps happen to be identical to get
+    // a consistent and in-order sort. (ingested_time)
+    if (!!this.fieldsConfig.secondaryIndex) {
+      search.sort.push({
+        [this.fieldsConfig.secondaryIndex]: {
+          order: (searchAfterAscending === true) ? 'asc' : 'desc'
+        }
+      });
+    }
 
     if (cursor !== undefined) {
       search.search_after = cursor

--- a/src/services/Log.ts
+++ b/src/services/Log.ts
@@ -8,6 +8,7 @@ import {TimeZone} from "./Prefs"
 
 export type FieldsConfig = {
   timestamp?: string
+  secondaryIndex?: string
   collapsedFormatting: ILogRule[]
   expandedFormatting?: ILogRule[]
   collapsedIgnore?: string[]


### PR DESCRIPTION
We have ms resolution on timestamps for log lines, so ordering
is not guaranteed for large numbers of logs. We added a secondary
index (ingested_at) with date_nano type to fix this. This commit
should add the ability to use this index in lq.

