### PR TITLE
Adds a default value for ingested_at value if not found

### DIFF
--- a/src/backends/elasticsearch/Elasticsearch.ts
+++ b/src/backends/elasticsearch/Elasticsearch.ts
@@ -60,6 +60,7 @@ interface SortItem {
   [key: string]: {
     order: "asc" | "desc",
     numeric_type?: string
+    missing?: any
   }
 }
 
@@ -181,7 +182,8 @@ export class Elasticsearch implements IDataSource {
     if (!!this.fieldsConfig.secondaryIndex) {
       search.sort.push({
         [this.fieldsConfig.secondaryIndex]: {
-          order: (searchAfterAscending === true) ? 'asc' : 'desc'
+          order: (searchAfterAscending === true) ? 'asc' : 'desc',
+          missing: 0
         }
       });
     }


### PR DESCRIPTION
it seems that the default value is set to MAX_LONG, which causes errors when trying to parse later on (in particular using the 'load more results' button)