### PR TITLE
Sanitize More HTML Outputs 

### DIFF
--- a/demo/generator/gen.go
+++ b/demo/generator/gen.go
@@ -144,7 +144,7 @@ func genPayload(when time.Time) (*bytes.Buffer, error) {
 		Timestamp: when.UTC().Format("2006-01-02T15:04:05-0700"),
 	}
 
-	switch rand.Int() % 3 {
+	switch rand.Int() % 4 {
 	case 0:
 		payload.Level = "INFO"
 		payload.Message = fmt.Sprintf("A descriptive info message %d", rand.Int())
@@ -154,6 +154,9 @@ func genPayload(when time.Time) (*bytes.Buffer, error) {
 	case 2:
 		payload.Level = "ERROR"
 		payload.Message = fmt.Sprintf("error running process %d with command %d", rand.Int()%32767, rand.Int())
+	case 3:
+		payload.Level = "INFO"
+		payload.Message = fmt.Sprintf("<!DOCTYPE html><html><head><title>Error: 404</title><style type=\"text/css\">body{background-color:#fff;color:#666;text-align:center;font-family:arial,sans-serif}div.dialog{width:25em;padding:0 4em;margin:4em auto 0 auto;border:1px solid #ccc;border-right-color:#999;border-bottom-color:#999}h1{font-size:100%;color:#f00;line-height:1.5em}</style></head><body><div class=\"dialog\"><h1>Test HTML Escaping</h1><p>This is a test for if HTML gets logged</p></div></body></html>")
 	}
 
 	switch rand.Int() % 5 {

--- a/src/services/Log.ts
+++ b/src/services/Log.ts
@@ -398,7 +398,7 @@ export class LogFormatter {
       const color = format.color ? `style="color:${format.color}"` : ''
 
       if (format.current && format.current !== "") {
-        fields += `<div ${clazz} ${color} ${tooltip}>${format.current}</div>&nbsp;`
+        fields += `<div ${clazz} ${color} ${tooltip}>${escape(format.current)}</div>&nbsp;`
       }
     }
     return fields
@@ -504,7 +504,7 @@ export class LogFormatter {
       v = JSON.stringify(obj)
     }
 
-    v = `<span class="strong value" data-key="${pathStr}" data-obj="${escape(JSON.stringify(originalObj))}">${v}</span>`
+    v = `<span class="strong value" data-key="${escape(pathStr)}" data-obj="${escape(JSON.stringify(originalObj))}">${v}</span>`
 
     return v
   }


### PR DESCRIPTION
# Purpose

This PR aims to fix a problem we ran into where HTML in a log broke the page because it wasn't escaped. Here's an example:

![Screen Shot 2021-02-05 at 1 56 57 PM](https://user-images.githubusercontent.com/4906712/107077630-26a7ab80-67bb-11eb-8896-31da30814c7e.png)

The black section is the hover styling for the log, but it shows  that there's a CSS declaration setting the `body` background to white.

## Changes
It turns out we render the log content in a few places, so this just touched up a couple of the places we could render HTML to sanitize it all.

![Screen Shot 2021-02-05 at 2 03 30 PM](https://user-images.githubusercontent.com/4906712/107078386-47243580-67bc-11eb-9886-3c087ec2bc9a.png)
![Screen Shot 2021-02-05 at 2 03 46 PM](https://user-images.githubusercontent.com/4906712/107078387-47bccc00-67bc-11eb-9b8b-2c0636e9b91d.png)

After adding the existing HTML escape function the UI is fixed:
![Screen Shot 2021-02-05 at 1 58 34 PM](https://user-images.githubusercontent.com/4906712/107078503-6b801200-67bc-11eb-9918-b9f2081cc410.png)

## Testing

I added a very simple HTML output that is a toned down version of what we saw in our logging cluster so that any future HTML logs will be caught.

