### PR TITLE
Add a button to _exclude_ terms from search

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       <div class="hover">
         <a class="copy-to-clipboard tooltip is-tooltip-right" data-tooltip="Copy value to clipboard"><i class="mdi mdi-content-copy"></i></a>
         <a class="add-to-query tooltip is-tooltip-right" data-tooltip="Add to current search"><i class="mdi mdi-filter-plus"></i></a>
+        <a class="exclude-from-query tooltip is-tooltip-right" data-tooltip="Exclude from current search"><i class="mdi mdi-filter-remove-outline"></i></a>
       </div>
       <div class="expanded is-hidden"></div>
     </div>

--- a/src/services/Log.ts
+++ b/src/services/Log.ts
@@ -277,6 +277,14 @@ export class LogFormatter {
       changeQuery(this.getAddQuery(key, obj))
     })
 
+    hover.querySelector(".exclude-from-query").addEventListener('click', () => {
+      // Exclude from query, for when the user left clicks
+      const key = lastFocus.dataset.key
+      const obj = unescape(lastFocus.dataset.obj)
+      const {changeQuery} = this._queryManipulator
+      changeQuery(this.getAddQuery(`-${key}`, obj))
+    })
+
     hover.addEventListener('mouseenter', () => {
       hovering = true
       lastFocus?.classList.add('focused')
@@ -307,6 +315,11 @@ export class LogFormatter {
       const query = this.getAddQuery(key, obj)
       const addToQuery = hover.querySelector(".add-to-query") as HTMLAnchorElement
       addToQuery.href = `?${query.toURL()}`
+
+      // Exclude from query, for when the user middle clicks
+      const excludeQuery = this.getAddQuery(`-${key}`, obj)
+      const excludeFromQuery = hover.querySelector(".exclude-from-query") as HTMLAnchorElement
+      excludeFromQuery.href = `?${excludeQuery.toURL()}`
 
       // Copy
       // https://stackoverflow.com/a/19470348/11125


### PR DESCRIPTION
When digging through logs, I find myself clicking the "Add to current search" button and then prefixing the term with a "-" to exclude it to filter out noisy stuff (such as Zookeeper logs, Datadog warnings, etc). It'd be way faster to just have a button to do that in one click.

I was unable to test this locally due to some `npm` issues, but it's pretty trivial so I'm hoping that's alright 🙏 