### PR TITLE
Show total count of results upon LQ Search

### DIFF
--- a/src/components/Logs.tsx
+++ b/src/components/Logs.tsx
@@ -13,6 +13,7 @@ export class Logs extends Component<Props, any> {
   render() {
     return (
       <div id="results" className="logs">
+        <div id="logs-count" class={this.props.visible ? "" : "is-hidden"}/>
         <div id="before-logs" className="entry more-marker"/>
         <div id="logs" ref={this.saveRef} class={this.props.visible ? "" : "is-hidden"}/>
         <div id="after-logs" className="entry more-marker"/>

--- a/src/services/Logquacious.test.ts
+++ b/src/services/Logquacious.test.ts
@@ -1,7 +1,7 @@
 import { Config, DataSourceType, Logquacious } from "./Logquacious"
 import { prepareApp, resultsFlatten } from "../helpers/TestHelper"
 import { Query } from "./Query"
-import { Cursor, HistogramResults, IDataSource, LogMessage, Result } from "../backends/elasticsearch/Elasticsearch"
+import { Cursor, HistogramResults, IDataSource, LogMessage, Result, TotalStats } from "../backends/elasticsearch/Elasticsearch"
 import { Direction } from "./Prefs"
 import { IRelative, Time } from "../helpers/Time"
 
@@ -14,9 +14,14 @@ class MockedElastic implements IDataSource {
 
   // @ts-ignore
   historicSearch(query: Query, cursor?: Cursor, searchAfterAscending?: boolean): Promise<Result> {
+    const total: TotalStats = {
+      value: this.logMessages.length,
+      relation: "eq"
+    }
     const r: Result = {
       overview: this.logMessages,
       full: Promise.resolve([new Map<string, LogMessage>()]),
+      totalStats: total
     }
     this.logMessages = []
     return Promise.resolve(r)

--- a/src/services/Logquacious.ts
+++ b/src/services/Logquacious.ts
@@ -322,6 +322,7 @@ export class Logquacious {
             that.results.append(logs[idx])
           }
         }
+        that.results.updateLogsCount()
         if (chunkEnd === length) {
           resolve()
           return

--- a/src/services/Logquacious.ts
+++ b/src/services/Logquacious.ts
@@ -276,7 +276,7 @@ export class Logquacious {
     if (nextPage) {
       this.results.saveScroll(nextPageOlder)
     }
-
+    this.results.updateLogsCount(logs.totalStats.value, logs.totalStats.relation)
     await this.staggerAppend(logs.overview, nextPage, nextPageOlder)
 
     this.results.updateMoreMarker(true, false)
@@ -322,7 +322,6 @@ export class Logquacious {
             that.results.append(logs[idx])
           }
         }
-        that.results.updateLogsCount()
         if (chunkEnd === length) {
           resolve()
           return

--- a/src/services/Results.ts
+++ b/src/services/Results.ts
@@ -24,6 +24,7 @@ export class Results {
   private tz: TimeZone
   private fieldsConfig: FieldsConfig
   private following: boolean
+  private logsCount: HTMLElement // the total count of logs in the selected time-frame
   private beforeLogs: HTMLElement
   private afterLogs: HTMLElement
   private savedScrollEntry: HTMLElement
@@ -41,6 +42,7 @@ export class Results {
 
   attach(element: HTMLElement, fieldsConfig: FieldsConfig, queryManipulator: QueryManipulator) {
     this.logs = element
+    this.logsCount = Lookup.element("#logs-count")
     this.beforeLogs = Lookup.element("#before-logs")
     this.beforeLogs.hidden = true
     this.afterLogs = Lookup.element("#after-logs")
@@ -76,6 +78,10 @@ export class Results {
 
     this.direction = direction
     this.swapDirection()
+  }
+
+  updateLogsCount() {
+    this.logsCount.innerHTML = "Total results = " + this.entries.length.toString()
   }
 
   followInterval() {
@@ -242,6 +248,7 @@ export class Results {
     this.beforeLogs.hidden = true
     this.afterLogs.hidden = true
     this.entries = []
+    this.logsCount.innerHTML = ''
     this.newChunk(this.direction)
   }
 

--- a/src/services/Results.ts
+++ b/src/services/Results.ts
@@ -24,7 +24,7 @@ export class Results {
   private tz: TimeZone
   private fieldsConfig: FieldsConfig
   private following: boolean
-  private logsCount: HTMLElement // the total count of logs in the selected time-frame
+  private logsCount: HTMLElement
   private beforeLogs: HTMLElement
   private afterLogs: HTMLElement
   private savedScrollEntry: HTMLElement
@@ -80,8 +80,14 @@ export class Results {
     this.swapDirection()
   }
 
-  updateLogsCount() {
-    this.logsCount.innerHTML = "Total results = " + this.entries.length.toString()
+  updateLogsCount(value: number, relation: string) {
+    if (relation === "eq") {
+      this.logsCount.innerHTML = "Total results = " + value
+    } else if (relation === "gte") {
+      this.logsCount.innerHTML = "Found at least " + value + " results"
+    } else {
+      this.logsCount.innerHTML = ""
+    }
   }
 
   followInterval() {

--- a/src/services/Results.ts
+++ b/src/services/Results.ts
@@ -82,7 +82,7 @@ export class Results {
 
   updateLogsCount(value: number, relation: string) {
     if (relation === "eq") {
-      this.logsCount.innerHTML = "Total results = " + value
+      this.logsCount.innerHTML = "Found exactly " + value + " results"
     } else if (relation === "gte") {
       this.logsCount.innerHTML = "Found at least " + value + " results"
     } else {


### PR DESCRIPTION
Currently there appears to be no way to easily tell exactly how many total logs were returned in the queried timeframe.

This can be specially lacking/limiting when investigating SEVs or debugging to quickly assess scope/impact
This PR adds a simple value indicating that count at the top of the search results.

**Please Note** - Due to [this Elastic optimization](https://www.elastic.co/guide/en/elasticsearch/reference/7.14//search-your-data.html#track-total-hits) the current count added with this PR will be exact only if <= 10k; beyond which the message will be like - `Found at least 10K` results. 

If this works well then as a follow up we can try out [track-total-hits feature of Elastic](https://www.elastic.co/guide/en/elasticsearch/reference/7.14//search-your-data.html#track-total-hits) to display exact count for larger (>10k) match results too.