### PR TITLE
Reverse recent search order so more recent searches are first

### DIFF
--- a/src/components/RecentSearches.tsx
+++ b/src/components/RecentSearches.tsx
@@ -15,7 +15,7 @@ export const RecentSearches = ({queries, onQuerySelection}: Props) => {
         query={query}
         onSelection={() => onQuerySelection(query)}
       />
-    )
+    ).reverse() // Puts more recent searches at the top of the list.
 
   if(queryListing.filter(item => item !== null).length === 0) return null
 


### PR DESCRIPTION
The recent search list has the most recent searches at the bottom, which is a bit annoying. Reversing the list is an easy way to remedy that.