### PR TITLE
Fixes errors caused by unrecognized tags

### DIFF
--- a/src/components/RecentSearches.tsx
+++ b/src/components/RecentSearches.tsx
@@ -45,6 +45,9 @@ const QueryListing = ({query, onSelection}: QueryListingProps) => {
 
   const filterTitle = (filter: Filter, value: string | null) => {
     const filterItem = filter.items.find(item => item.id === value)
+    if (filterItem === undefined) {
+      return null;
+    }
     return filterItem.shortTitle === undefined ? filterItem.title : filterItem.shortTitle
   }
 
@@ -67,9 +70,11 @@ const QueryListing = ({query, onSelection}: QueryListingProps) => {
       <span className="tag is-primary is-light">
         {whenToText(query.startTime)} &ndash; {whenToText(query.endTime)}
       </span>
-      {activeFilters.map(
-        filter => <span className="tag is-primary is-light">{filter.title}: {filterTitle(filter,
-          filter.selected)}</span>)}
+      {activeFilters.map((filter) => {
+         const title = filterTitle(filter, filter.selected);
+         return title ? <span className="tag is-primary is-light">{filter.title}: {filterTitle(filter, filter.selected)}</span> : null;
+        })
+      }
     </div>
   </div>
 };


### PR DESCRIPTION
@jonwinton I can't add you as reviewer for some reason

So alternative here is to display the name with no title, but this also is fairly confusing (ie the issue occurs when we don't have a real label for a tag, so having no tag name but a description may be even more confusing)

example case
if instead of `e:cash-prod` (e is our shorthand for env), we have `e:production`, right now the tag ui will crash. 
If we just display what we can, users will see `Env: production` as a tag, but get 0 results
if we don't display anything, they will not see this tag at all, and get 0 results. If they look at the environment tabs in the top, none will be selected. I find this to be clearer than 'fake suggesting' that it's a non-existent cluster if the name of the environment doesn't match

This resolves
SUPPORT-573
SUPPORT-659
